### PR TITLE
Feature/expand workouts to 30 days

### DIFF
--- a/controllers/workouts.js
+++ b/controllers/workouts.js
@@ -70,7 +70,7 @@ async function updateWorkout (req, res) {
             .populate('exercise.movement');
         
         if (!workout) 
-                return res.status(404).send('Workout not found');
+                return res.status(404).json({ message: 'Workout not found' });
 
         /* req.body.exercise structure example with 3 movements (weighted, cardio, weighted)
             {
@@ -98,7 +98,6 @@ async function updateWorkout (req, res) {
             // works to use validation on pre save      
         Object.assign(workout, req.body);
         await workout.save();
-
 
         res.redirect('/workouts');
 

--- a/models/workout.js
+++ b/models/workout.js
@@ -1,10 +1,12 @@
 const mongoose = require('mongoose');
 const { exerciseSchemaMiddleware } = require('../middleware/exercise');
 
+const { months } = require('../utilities/constants');
+
 
 const workoutSchema = new mongoose.Schema({
     day: {
-        type: String,
+        type: Date,
         required: true
     },
     exercise: {
@@ -49,9 +51,19 @@ const workoutSchema = new mongoose.Schema({
         required: true
     }
 }, {
-    timestamps: true
+    timestamps: true,
+    toJSON: { virtuals: true }
 });
 
+// validation for workout.day
+workoutSchema.pre('save', async function (next) {
+    const now = new Date();
+    // calculate 30 days from now
+    const in30Days = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+    if (this.day < now || this.day > in30Days) 
+        return next(new Error('Workout cannot be before today\'s date for more than 30 days in the future'));
+});
 
 // checks exercise.movement.type and validates required associated fields prior to saving workout
 workoutSchema.pre('save', async function (next) {
@@ -72,6 +84,14 @@ workoutSchema.pre('save', async function (next) {
 
     // if all exercise validation requirements are met, move to save instance
     next();
+});
+
+// virtual property for formatting day for rendering in view
+workoutSchema.virtual('formattedDay').get(function () {
+    if (this.day instanceof Date) 
+        return `${months[this.day.getUTCMonth()]} ${this.day.getUTCDate()}`;
+
+    else return null;
 });
 
 

--- a/models/workout.js
+++ b/models/workout.js
@@ -55,15 +55,6 @@ const workoutSchema = new mongoose.Schema({
     toJSON: { virtuals: true }
 });
 
-// validation for workout.day
-workoutSchema.pre('save', async function (next) {
-    const now = new Date();
-    // calculate 30 days from now
-    const in30Days = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
-
-    if (this.day < now || this.day > in30Days) 
-        return next(new Error('Workout cannot be before today\'s date for more than 30 days in the future'));
-});
 
 // checks exercise.movement.type and validates required associated fields prior to saving workout
 workoutSchema.pre('save', async function (next) {
@@ -84,6 +75,22 @@ workoutSchema.pre('save', async function (next) {
 
     // if all exercise validation requirements are met, move to save instance
     next();
+});
+
+// validation for workout.day
+workoutSchema.pre('save', async function (next) {
+    const now = new Date();
+    now.setUTCHours(0, 0, 0, 0);
+    // calculate 30 days from now
+    const in30Days = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+    if (this.day < now || this.day > in30Days) {
+        const error = new mongoose.Error.ValidationError(this);
+        error.message = 'Workout cannot be before today\'s date or more than 30 days in the future';
+        return next(error);
+    }
+
+    else next();
 });
 
 // virtual property for formatting day for rendering in view

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -62,6 +62,10 @@ footer {
     height: 1rem;
 }
 
+input[type="date"].form-control {
+    height: 3rem;
+}
+
 .welcome-form {
     width: 50vh;
     align-self: center;

--- a/seed/seedControllers.js
+++ b/seed/seedControllers.js
@@ -58,7 +58,7 @@ async function seedWorkout () {
         const cleanAndJerk = await Movement.findOne({ name: 'Clean and Jerk' });
 
         await Workout.create({
-            day: 'Monday',
+            day: new Date(),
             exercise: [
                 {
                     movement: snatch._id,

--- a/utilities/constants.js
+++ b/utilities/constants.js
@@ -2,5 +2,11 @@ const muscleGroups = [
     'Deltoids', 'Triceps', 'Biceps', 'Forearms', 'Chest', 'Abdominals', 'Upper Back', 'Lower Back', 'Glutes', 'Quadriceps', 'Hamstrings', 'Calves'
 ];
 
+const months = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December'
+];
 
-module.exports = {  muscleGroups }
+
+
+module.exports = {  muscleGroups, months }

--- a/views/workout/edit.ejs
+++ b/views/workout/edit.ejs
@@ -13,14 +13,11 @@
             <form action="/workouts/<%= workout._id %>?_method=PUT" method="POST">
                 <div class="row center">
                     <div class="w-50">
-                        <p class="fs-7 fst-italic">Select Day:</p>
-                        <select name="day" class="form-select" size="4" required>
-                            <% for (const day of daysOfTheWeek) { %>
-                                <option class="select-text" value="<%= day %>" <% if (workout.day === day) { %> selected<% } %>>
-                                    <%= day %>
-                                </option>
-                            <% } %>
-                        </select>
+                        <label class="fs-6 fst-italic mb-2" for="day">Select Day:</label>
+                        <input class="form-control" type="date" placeholder="Select Day:" name="day" required
+                            min="<%= new Date().toISOString().split('T')[0] %>"
+                            max="<%= new Date(new Date().setDate(new Date().getDate() + 30)).toISOString().split('T')[0] %>"
+                            value="<%= workout.day.toISOString().split('T')[0] %>">
                     </div>
                 </div>
                 <h4 class="mt-4">Exercise Details</h4>

--- a/views/workout/index.ejs
+++ b/views/workout/index.ejs
@@ -23,7 +23,7 @@
 
                     <div class="card m-4">
                         <a href="workouts/<%= workout._id %>">
-                            <h4><%= workout.day %></h4>
+                            <h4><%= workout.formattedDay %></h4>
                         </a>
                         <li class="card-body center text-capitalize">
                             <% for (const exercise of workout.exercise) { %>

--- a/views/workout/new.ejs
+++ b/views/workout/new.ejs
@@ -3,7 +3,7 @@
 
 <%- include('../partials/head'); %>
 
-<% const daysOfTheWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']; %>
+<% const daysOfTheWeek = ['08-18', '08-19', '08-20']; %>
 
 <body>
     <div class="container">
@@ -13,15 +13,13 @@
             <form action="/workouts" method="POST">
                 <div class="row mb-3 center">
                     <div class="w-50">
-                        <p class="fs-7 fst-italic">Select Day:</p>
-                        <select name="day" class="form-select" size="4" required>
-                            <% for (const day of daysOfTheWeek) { %>
-                                <option class="select-text" value="<%= day %>"><%= day %></option>
-                            <% } %>
-                        </select>
+                        <label class="fs-6 fst-italic mb-2" for="day">Select Day:</label>
+                        <input class="form-control" type="date" placeholder="Select Day:" name="day" required
+                            min="<%= new Date().toISOString().split('T')[0] %>"
+                            max="<%= new Date(new Date().setDate(new Date().getDate() + 30)).toISOString().split('T')[0] %>">
                     </div>
                 </div>
-                <h4 class="mt-4 px-5">Exercise Details</h4>
+                <h4 class="mt-5 px-5">Exercise Details</h4>
                 <div class="workoutInputParent">
                     <div class="workoutInputChild">
                         <div class="index">

--- a/views/workout/show.ejs
+++ b/views/workout/show.ejs
@@ -7,7 +7,7 @@
     <div class="container">
         <%- include('../partials/nav'); %>
         <div class="container-md">
-            <h2><%= workout.day %></h2>
+            <h2><%= workout.formattedDay %></h2>
             <div class="right index my-1">
                 <button id="addFavorite" class="btn btn-outline-warning btn-sm">Add to Favorites</button>
                 <form action="/workouts/<%= workout._id %>/favorite" method="POST" autocomplete="off" class="d-none favorite">


### PR DESCRIPTION
Updates `workoutSchema` to expand workout storage from 7 days to 30 days. 

Models -->
- workout
     - changes day attribute to type Date
     - adds pre save validation to ensure that day is no less than current date and no more than 30 days from current date
     - adds virtual `formattedDay` field that stores the date as a string with month name and day
     - includes virtuals in toJSON

Controllers -->
- sorts by day on index to return workouts ordered by soonest date first
- fixes issue with validation of exercises occurring after creation / updating workout
- alters way workout is updated to make use of workout.save() and pass workout through day pre save validation
- uses toJSON in show and index controllers to utilize `formattedDay` field

Views -->
- workout/index.ejs, workout/show.ejs
     - Uses `workout.formattedDay` for render
- workout/new.ejs, workout/edit.ejs
     - Replaces select daysOfTheWeek tag with input of type date and restricts to 30 days from current date
           - adds styles to new date input

Tests --> updates and adds models and controller tests to account for changes
Seed --> updates workout seed data to account for change to schema