### PR TITLE
Refactor/sharing favorites

### DIFF
--- a/controllers/favorites.js
+++ b/controllers/favorites.js
@@ -119,6 +119,27 @@ async function copyFavorite (req, res) {
     }
 }
 
+// toggle isPublic status
+async function toggleIsPublic (req, res) {
+    try {
+        const favorite = await Favorite.findOneAndUpdate(
+            { createdBy: req.session.userId, _id: req.params.id },
+            [ 
+                { $set: { isPublic: { $not: '$isPublic' } } }, // toggles boolean by setting to opposite value
+            ],
+        );
+
+        // if favorite is resolved, send success
+        if (favorite) return res.status(200).json({ message: 'Favorite updated successfully', reload: true }); 
+        // else throw error
+        else return res.status(404).json({ error: 'Favorite not found', reload: true });
+
+    } catch (error) {
+        res.status(500).json({ error: 'An error occurred while toggling the favorite\'s public status', reload: true });
+    }
+}
+
+
 // create
 async function createFavorite (req, res) {
     try {
@@ -196,7 +217,7 @@ async function showFavorite (req, res) {
 }
 
 // sees if the movement within the favorite exists in reference to user, creates the movement if not
-async function createOrRetrieveMovement(exercise, createdBy) {
+async function createOrRetrieveMovement (exercise, createdBy) {
     // search for movement
     let movement = await Movement.findOne({
         name: exercise.movement.name,
@@ -217,4 +238,4 @@ async function createOrRetrieveMovement(exercise, createdBy) {
 }
 
 
-module.exports = { getFavorites, deleteFavorite, shareFavorites, copyFavorite, createFavorite, showFavorite }
+module.exports = { getFavorites, deleteFavorite, shareFavorites, copyFavorite, toggleIsPublic, createFavorite, showFavorite }

--- a/controllers/favorites.js
+++ b/controllers/favorites.js
@@ -44,8 +44,8 @@ async function deleteFavorite (req, res) {
 // share favorirtes
 async function shareFavorites (req, res) {
     try {
-        const originalFavorite = await Favorite.findOne({
-            createdBy: req.session.userId,
+        const originalFavorite = await Favorite.findById({
+            createdBy: req.body.friend,
             _id: req.params.id
         })
         .lean();
@@ -68,7 +68,7 @@ async function shareFavorites (req, res) {
         const favoriteToShare = new Favorite({
             name: originalFavorite.name,
             exercise: originalFavorite.exercise,
-            createdBy: req.body.friend
+            createdBy: req.session.userId
         });
 
         const sharedFavorite = await favoriteToShare.save();

--- a/controllers/favorites.js
+++ b/controllers/favorites.js
@@ -146,8 +146,7 @@ async function toggleIsPublic (req, res) {
 async function createFavorite (req, res) {
     try {
         const workout = await Workout.findById(req.params.id)
-            .populate('exercise.movement')
-            .lean();
+            .populate('exercise.movement');
         
         // send error if workout doesn't exist
         if (!workout) return res.status(404).json({ error: 'Workout not found' });
@@ -175,7 +174,7 @@ async function createFavorite (req, res) {
         const createdFavorite = await Favorite.create(newFavorite); // creates favorite
 
         res.render('workout/show.ejs', {
-            workout,
+            workout: workout.toJSON(),
             message: 'Favorite added!' // confirmation message
         });
 

--- a/models/favorite.js
+++ b/models/favorite.js
@@ -52,6 +52,11 @@ const favoriteSchema = new mongoose.Schema({
         required: true,
         default: undefined
     },
+    isPublic: {
+        type: Boolean,
+        default: true,
+        required: true
+    },
     createdBy: {
         type: mongoose.Schema.Types.ObjectId,
         ref: 'User',

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,5 +1,6 @@
 $(document).ready(function () {
-    const URL = 'https://weightlifting-log.herokuapp.com/'
+    // const URL = 'https://weightlifting-log.herokuapp.com/';
+    const URL = 'http://localhost:3000/';
 
     // password and confirmation field inputs
     const $password = $('#password');
@@ -36,6 +37,7 @@ $(document).ready(function () {
     $inputParent.on('click', $delete, deleteExercise);
     $add.on('click', addExercise);
     $complete.on('change', updateProgress);
+    $('.isPublic').on('click', togglePublic);
     $('#addFavorite, #copy, #editProfile, .movementDelete').on('click', function (evt) {
         evt.preventDefault();
         let selectors;
@@ -93,7 +95,7 @@ $(document).ready(function () {
     }
 
     // updates workout completion progress on workout show template
-    function updateProgress(evt) {
+    function updateProgress (evt) {
         const isChecked = $(evt.target).is(':checked');
 
         if (isChecked) completedWorkouts += 1;
@@ -119,7 +121,7 @@ $(document).ready(function () {
     }
 
     // for profile photo submit button
-    function enableSubmit(evt) {
+    function enableSubmit (evt) {
         if ($(evt.target).val() !== '') $(evt.target).siblings().removeAttr('disabled');
     }
 
@@ -168,8 +170,31 @@ $(document).ready(function () {
         if (evt.target.id === 'friendsCollapse') $friend.slideToggle();
     }
 
+    async function togglePublic (evt) {
+        id = evt.target.id;
+        const button = $(evt.target);
+
+        const response = await fetch(URL + 'favorites/' + id + '/toggle-public?_method=PUT', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'Application/json',
+            },
+            body: JSON.stringify({
+                'id': `${id}`,
+            })
+        });
+
+        // toggles classes for styles if response was successful
+        if (response.ok) {
+            if (button.hasClass('btn-success'))
+                button.removeClass('btn-success').addClass('btn-danger').text('Private');
+            else 
+                button.removeClass('btn-danger').addClass('btn-success').text('Public');
+        }
+    }
+
     // updates workout completion status
-    async function completeWorkout(id) {
+    async function completeWorkout (id) {
         await fetch(URL + 'workouts/' + id + '/complete?_method=PUT', {
             method: 'POST',
             headers: {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -36,13 +36,12 @@ $(document).ready(function () {
     $inputParent.on('click', $delete, deleteExercise);
     $add.on('click', addExercise);
     $complete.on('change', updateProgress);
-    $('#addFavorite, #copy, #share, #editProfile, .movementDelete').on('click', function (evt) {
+    $('#addFavorite, #copy, #editProfile, .movementDelete').on('click', function (evt) {
         evt.preventDefault();
         let selectors;
 
         if ($(this).is('#addFavorite')) selectors = ['.favorite'];
         else if ($(this).is('#copy')) selectors = ['.copy'];
-        else if ($(this).is('#share')) selectors = ['.share'];
         else if ($(this).is('.movementDelete')) { 
             const $button = $(this);
             $div = $($button.closest('div'));
@@ -111,7 +110,7 @@ $(document).ready(function () {
         }
     }
 
-    // toggles hidden forms for editing profile, adding favorites, sharing favorites and copying favorites to workouts
+    // toggles hidden forms for editing profile, adding favorites, and copying favorites to workouts
     function toggleForms (selectors) {
         for (const selector of selectors) {
             const $element = $(selector);

--- a/routes/favorites.js
+++ b/routes/favorites.js
@@ -10,6 +10,7 @@ router.post('/favorites/:id/copy', favoritesController.copyFavorite);
 router.post('/workouts/:id/favorite', favoritesController.createFavorite);
 router.put('/favorites/:id/toggle-public', favoritesController.toggleIsPublic);
 router.get('/favorites/:id', favoritesController.showFavorite);
+router.get('/users/:username/favorites', favoritesController.viewOtherFavorites);
 
 
 module.exports = router;

--- a/routes/favorites.js
+++ b/routes/favorites.js
@@ -8,6 +8,7 @@ router.delete('/favorites/:id', favoritesController.deleteFavorite);
 router.post('/favorites/:id/share', favoritesController.shareFavorites);
 router.post('/favorites/:id/copy', favoritesController.copyFavorite);
 router.post('/workouts/:id/favorite', favoritesController.createFavorite);
+router.put('/favorites/:id/toggle-public', favoritesController.toggleIsPublic);
 router.get('/favorites/:id', favoritesController.showFavorite);
 
 

--- a/routes/profiles.js
+++ b/routes/profiles.js
@@ -8,7 +8,7 @@ router.put('/users/me/photo/edit', profilesController.uploadPhoto);
 router.put('/users/me/bio/edit', profilesController.updateProfile);
 router.get('/users/search', profilesController.searchView);
 router.post('/users/search', profilesController.handleSearch);
-router.get('/users/profile/:username', profilesController.viewOtherProfile);
+router.get('/users/:username/profile', profilesController.viewOtherProfile);
 
 
 module.exports = router;

--- a/tests/controllers/profiles.test.js
+++ b/tests/controllers/profiles.test.js
@@ -162,12 +162,12 @@ describe('GET /users/search', () => {
     });
 });
 
-describe('GET /users/profile/:username', () => {
+describe('GET /users/:username/profile', () => {
     test('should successfully render another user\'s profile view', async () => {
         const otherUser = await User.findById(johnId);
 
         const response = await testSession
-            .get(`/users/profile/${otherUser.username}`)
+            .get(`/users/${otherUser.username}/profile`)
             .expect(200);
 
         // checking to see if other user's info is present
@@ -205,7 +205,7 @@ describe('GET /users/profile/:username', () => {
         const self = await User.findById(janeId); // search for logged in user
 
         const response = await testSession
-            .get(`/users/profile/${self.username}`)
+            .get(`/users/${self.username}/profile`)
             .expect(302);
 
         // checking that user was redirected to url for own profile
@@ -218,7 +218,7 @@ describe('GET /users/profile/:username', () => {
         expect(count).toBe(0);
 
         const response = await testSession
-            .get('/users/profile/invalid') // username is 'invalid'
+            .get('/users/invalid/profile') // username is 'invalid'
             .expect(404);
 
         // checking for error

--- a/tests/models/favorite.test.js
+++ b/tests/models/favorite.test.js
@@ -4,7 +4,6 @@ const User = require('../../models/user');
 const Favorite = require('../../models/favorite');
 const { expectValidationError } = require('../testUtilities');
 const movementData = require('../../seed/movementData');
-const user = require('../../models/user');
 
 require('dotenv').config();
 

--- a/views/favorite/index.ejs
+++ b/views/favorite/index.ejs
@@ -59,7 +59,8 @@
                         <div class="card-footer">
                             <p>
                             <% if (viewer) { %>
-                                <form action="/favorites/<%= favorite._id %>/share?_method=PUT" method="POST">
+                                <form action="/favorites/<%= favorite._id %>/share?_method=POST" method="POST">
+                                    <input type="hidden" name="friend" value="<%= user._id %>">
                                     <input type="submit" value="Save Favorite" class="btn btn-outline-success btn-sm">
                                 </form>
                             <% } else { %>

--- a/views/favorite/index.ejs
+++ b/views/favorite/index.ejs
@@ -7,14 +7,23 @@
     <div class="container">
         <%- include('../partials/nav'); %>
         <div class="container-md">
-            <h2>Favorite Workouts</h2>
+            <% if (viewer) { %>
+                <h2 class="text-capitalize"><%= user.username %>'s Favorite Workouts</h2>
+            <% } else { %>
+                <h2>Favorite Workouts</h2>
+            <% } %>
+
             <ul class="index">
                 <% displayFavorite(0); %>
                 <% function displayFavorite (index) { %>
                     <% if (favorites.length === 0) { %>
                         <div class="center mb-5">
-                            <a href="/workouts/new" class="btn btn-outline-secondary btn">Save workouts by adding them to
-                                your favorites!</a>
+                            <% if (viewer) { %>
+                                <p>No available favorites</p>
+                            <% } else { %>
+                                <a href="/workouts/new" class="btn btn-outline-secondary btn">Save workouts by adding them to
+                                    your favorites!</a>
+                            <% } %>
                         </div>
                         <% return; %>
                     <% } %>
@@ -23,21 +32,41 @@
                     <% const favorite = favorites[index]; %>
 
                     <div class="card m-4">
-                        <a href="favorites/<%= favorite._id %>">
+                        <% if (viewer) { %>
                             <h4 class="text-capitalize"><%= favorite.name %></h4>
-                        </a>
+                        <% } else { %>
+                            <a href="favorites/<%= favorite._id %>">
+                                <h4 class="text-capitalize"><%= favorite.name %></h4>
+                            </a>
+                        <% } %>
                         <li class="card-body center">
                             <% for (const exercise of favorite.exercise) { %>
                                 <%= exercise.movement.name %>
+                                <% if (viewer) { %>
+                                    <% if (exercise.movement.type === 'weighted') { %>
+                                        : <%= exercise.weight %>lbs, 
+                                        <%= exercise.sets %> x 
+                                        <%= exercise.reps %>
+                                    <% } else { %>
+                                        : <%= exercise.minutes %> mins,
+                                        <%= exercise.caloriesBurned %> cal
+                                    <% } %>
+                                <% } %>
                                 <br>
                             <% } %>
                         </li>
                         </a>
                         <div class="card-footer">
                             <p>
+                            <% if (viewer) { %>
+                                <form action="/favorites/<%= favorite._id %>/share?_method=PUT" method="POST">
+                                    <input type="submit" value="Save Favorite" class="btn btn-outline-success btn-sm">
+                                </form>
+                            <% } else { %>
                                 <form action="/favorites/<%= favorite._id %>?_method=DELETE" method="POST">
                                     <input type="submit" value="Delete Favorite" class="btn btn-outline-danger btn-sm">
                                 </form>
+                            <% } %>
                             </p>
                         </div>
                     </div>

--- a/views/favorite/show.ejs
+++ b/views/favorite/show.ejs
@@ -3,7 +3,6 @@
 
 <%- include('../partials/head'); %>
 
-<% const daysOfTheWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']; %>
 
 <body>
     <div class="container">
@@ -49,13 +48,11 @@
                 <button class="btn btn-outline-warning btn-xs mb-2" id="copy">Copy to Workouts</button>
                 <form class="d-none copy" action="/favorites/<%= favorite._id %>/copy" method="POST">
                     <input type="hidden" name="id" value="<%= favorite._id %>">
-                    <p class="fs-7 fst-italic mx-5">Select Day:</p>
-                    <div class="center">
-                        <select name="day" class="form-select w-50" size="4" required>
-                            <% for (const day of daysOfTheWeek) { %>
-                                <option class="select-text" value="<%= day %>"><%= day %></option>
-                            <% } %>
-                        </select>
+                    <div class="w-50">
+                        <label class="fs-6 fst-italic mb-2" for="day">Select Day:</label>
+                        <input class="form-control" type="date" placeholder="Select Day:" name="day" required
+                            min="<%= new Date().toISOString().split('T')[0] %>"
+                            max="<%= new Date(new Date().setDate(new Date().getDate() + 30)).toISOString().split('T')[0] %>">
                     </div>
                     <div class="right">
                         <input type="submit" value="Create Workout" class="btn btn-outline-success btn-xs mt-1 mb-2 mx-3">

--- a/views/favorite/show.ejs
+++ b/views/favorite/show.ejs
@@ -9,6 +9,13 @@
         <%- include('../partials/nav'); %>
         <div class="container-md">
             <h2 class="text-capitalize"><%= favorite.name %></h2>
+            <div class="right index my-1">
+                <button 
+                class="btn <%= favorite.isPublic ? 'btn-success' : 'btn-danger' %> btn-xs mb-2 isPublic" 
+                id="<%= favorite._id %>">
+                <%= favorite.isPublic ? 'Public' : 'Private' %>
+            </button>            
+            </div>
             <div class="index">
                 <% for (const exercise of favorite.exercise) { %>
                     <div class="exercise m-2">

--- a/views/favorite/show.ejs
+++ b/views/favorite/show.ejs
@@ -28,23 +28,6 @@
             <br>
             <br>
             <div class="mb-1">
-                <button class="btn btn-outline-info btn-xs mb-2" id="share">Share Favorite</button>
-                <form class="d-none share" action="/favorites/<%= favorite._id %>/share" method="POST">
-                    <input type="hidden" name="id" value="<%= favorite._id %>">
-                    <p class="fs-7 fst-italic mx-5">Select a Friend:</p>
-                    <div class="center">
-                        <select id="friends" name="friend" class="form-select w-50" size="4" required>
-                            <% for (const friend of friends) { %>
-                                <option value="<%= friend._id %>" class="text-capitalize select-text"><%= friend.username %></option>
-                            <% } %>
-                        </select>
-                    </div>
-                    <div class="right">
-                        <input type="submit" value="Submit Share" class="btn btn-outline-success btn-xs mt-1 mb-2 mx-3">
-                    </div>
-                </form>
-            </div>
-            <div class="mb-1">
                 <button class="btn btn-outline-warning btn-xs mb-2" id="copy">Copy to Workouts</button>
                 <form class="d-none copy" action="/favorites/<%= favorite._id %>/copy" method="POST">
                     <input type="hidden" name="id" value="<%= favorite._id %>">

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -122,8 +122,7 @@
                         <% } else if (existingRequest.status === 'pending') { %>
                             <h5>Request Pending</h5>
                         <% } else if (existingRequest.status === 'accepted') { %>
-                            <h5>You can now share your favorite workouts with <p class="text-capitalize"><%= user.username %>!</p></h5>
-                            <a href="/favorites">Click here to browse favorites</a>
+                            <a href="/favorites">Click here to browse <%= user.username %>'s favorites</a>
                         <% } %>
                     </div>
                 <% } else { %>
@@ -136,7 +135,7 @@
                                         <% const pending = request.to._id.toHexString() === user._id.toHexString() ? request.from : request.to %>
                                         <% if (pending === request.from) { %>
                                             <li class="py-1 px-3">
-                                                <a href="/users/profile/<%= pending.username %>"><%= pending.username %></a>
+                                                <a href="/users/<%= pending.username %>/profile"><%= pending.username %></a>
                                                 <form action="/users/request/edit/?_method=PUT" method="POST">
                                                     <input type="hidden" name="requestId" value="<%= request._id %>">
                                                     <input type="submit" name="decision" value="Accept" class="btn btn-outline-success btn-xs">
@@ -145,7 +144,7 @@
                                             </li>
                                         <% } else if (pending === request.to) { %>
                                         <li class="py-1 px-3">
-                                            <a class="text-capitalize" href="/users/profile/<%= pending.username %>"><p><%= pending.username %></p></a>
+                                            <a class="text-capitalize" href="/users/<%= pending.username %>/profile"><p><%= pending.username %></p></a>
                                         </li>
                                         <% } %>
                                     <% } %>
@@ -166,7 +165,7 @@
                                     <% for (const friendship of friendships) { %>
                                         <% const friend = friendship.to._id.toHexString() === user._id.toHexString() ? friendship.from : friendship.to %>
                                         <li class="py-1 px-3">
-                                            <a class="text-capitalize" href="/users/profile/<%= friend.username %>"><p><%= friend.username %></p></a>
+                                            <a class="text-capitalize" href="/users/<%= friend.username %>/profile"><p><%= friend.username %></p></a>
                                         </li>
                                     <% } %>
                                 <% } else { %>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -122,7 +122,7 @@
                         <% } else if (existingRequest.status === 'pending') { %>
                             <h5>Request Pending</h5>
                         <% } else if (existingRequest.status === 'accepted') { %>
-                            <a href="/favorites">Click here to browse <%= user.username %>'s favorites</a>
+                            <a href="/users/<%= user.username %>/favorites">Click here to browse <%= user.username %>'s favorites</a>
                         <% } %>
                     </div>
                 <% } else { %>

--- a/views/search.ejs
+++ b/views/search.ejs
@@ -32,7 +32,7 @@
                         <ul class="index-grid w-75 mx-3">
                             <% for (const user of searchResults) { %>
                                 <li class="text-center">
-                                    <a href="/users/profile/<%= user.username %>" class="text-capitalize">
+                                    <a href="/users/<%= user.username %>/profile" class="text-capitalize">
                                         <img src="<%= user.profilePhoto %>" alt="<%= user.username %>'s profile photo" class="rounded" width="60px" height="60px">
                                         <br>
                                         <p><%= user.username %></p>


### PR DESCRIPTION
Updates how favorites are shared by allowing the user to choose to save a copy of a favorite from a friend's list of public favorites. 

Models -->
- favorite
     - adds a `isPublic` boolean field to allow users to have publicly accessible and private favorites


Controllers -->
- favorite
      - adds a toggle public controller that toggles the `isPublic` field
      - adds controller to respond with list of friend's public favorites


Views -->
- profile
      - fixes links to account for route changes
      - replaces message about sharing favorites with link to friend's public favorites
- favorite
      - repurposes favorite index page to also render index of friend's public favorites
           - on friend's public favorite index --> removes link to show page, and instead renders details within card
     - adds toggle public button on user's favorite show page


Public -->
- js
    - removes event handlers associated with previous share favorite functionality
    - adds event handler on public to toggle public


Tests --> updates and adds model and controller tests to account for changes