### PR TITLE
Bugfix/cardio movements

### DIFF
--- a/controllers/movements.js
+++ b/controllers/movements.js
@@ -84,12 +84,20 @@ async function updateMovement (req, res) {
          // req.body in format of musclesWorked: { muscle: 'on', muscle: 'on' }, must reformat before creating instance
         const editMovement = formatMovementData(req.body, req.session.userId); // format req.body per schema
 
-        const updatedMovement = await Movement.findOneAndUpdate({
+        const movement = await Movement.findOne({
             createdBy: req.session.userId,
             _id: req.params.id
-        }, editMovement, { new: true });
+        });
+
+        if (!movement) return res.status(404).json({ error: 'Movement not found '});
+
+        // apply updates and save 
+            // works to use validation on pre save  
+        Object.assign(movement, editMovement);
+        await movement.save();
 
         res.redirect('/movements');
+
     } catch (error) {
         res.status(500).send('An error occurred while updating the movement.');
     }

--- a/controllers/movements.js
+++ b/controllers/movements.js
@@ -8,10 +8,18 @@ async function getMovements (req, res) {
     try {
         const pageSize = 8;
         const page = req.query.page || 1;
+        const typeFilter = req.query.typeFilter;
+        const muscleFilter = req.query.muscle ? req.query.muscle.split(',') : [];
 
         // creates filtering parameters
         const filter = {}
-        if (req.query.muscle) filter.musclesWorked = { $all: req.query.muscle };
+        if (typeFilter === 'cardio') {
+            filter.type = 'cardio';
+        }
+        else if (typeFilter === 'weighted') {
+            filter.type = 'weighted';
+            if (req.query.muscle) filter.musclesWorked = { $all: req.query.muscle };
+        }
 
         // count of all the movements accessible by user
         const totalMovements = await Movement.countDocuments({
@@ -40,6 +48,8 @@ async function getMovements (req, res) {
         res.render('movement/index.ejs', {
             movements,
             muscleGroups,
+            typeFilter,
+            muscleFilter,
             currentPage: page,
             totalPages
         });

--- a/controllers/movements.js
+++ b/controllers/movements.js
@@ -69,14 +69,14 @@ function newMovementView (req, res) {
 // delete
 async function deleteMovement (req, res) {
     try {
-        const deletedMovement = await Movement.findOneAndDelete({
+        const deletedMovement = await Movement.findOne({
             createdBy: req.session.userId,
             _id: req.params.id
         });
 
         if (!deletedMovement) return res.status(404).json({ error: 'Movement not found', reload: true });
 
-        await deletedMovement.remove();
+        await deletedMovement.deleteOne();
 
         res.redirect('/movements');
     } catch (error) {

--- a/controllers/movements.js
+++ b/controllers/movements.js
@@ -77,7 +77,7 @@ async function deleteMovement (req, res) {
 // update
 async function updateMovement (req, res) {
     try {
-        if (!req.body.name || !req.body.musclesWorked || !req.body.type) {
+        if (!req.body.name || !req.body.type) {
             return res.status(400).json({ error: 'Invalid input', reload: true });
         }
 
@@ -106,7 +106,7 @@ async function updateMovement (req, res) {
 // create
 async function createMovement (req, res) {
     try {
-        if (!req.body.name || !req.body.musclesWorked || !req.body.type) {
+        if (!req.body.name || !req.body.type) {
             return res.status(400).json({ error: 'Invalid input', reload: true });
         }
 

--- a/controllers/workouts.js
+++ b/controllers/workouts.js
@@ -78,6 +78,7 @@ async function updateWorkout (req, res) {
                 weight: ['weight 1', '', 'weight 3'],
                 sets: ['sets 1', '', 'sets 3'],
                 reps: ['reps 1', '', 'reps 3'],
+                distance: ['', 'distance 2', ''],
                 minutes: ['', 'minutes 2', ''],
                 caloriesBurned: ['', 'caloriesBurned 2', ''],
             }
@@ -116,6 +117,7 @@ async function createWorkout (req, res) {
                 weight: ['weight 1', '', 'weight 3'],
                 sets: ['sets 1', '', 'sets 3'],
                 reps: ['reps 1', '', 'reps 3'],
+                distance: ['', 'distance 2', ''],
                 minutes: ['', 'minutes 2', ''],
                 caloriesBurned: ['', 'caloriesBurned 2', ''],
             }

--- a/middleware/exercise.js
+++ b/middleware/exercise.js
@@ -1,5 +1,5 @@
 // based on movement type, makes certain fields on exercise instance required 
-    // cardio types -- minutes, caloriesBurned
+    // cardio types -- minutes, distance, caloriesBurned
     // weighted types -- weight, sets, reps 
 function exerciseSchemaMiddleware (exercise) {
 
@@ -7,8 +7,8 @@ function exerciseSchemaMiddleware (exercise) {
     if (exercise.movement.type === 'cardio') {
 
         // throw error if missing:
-        if (!exercise.minutes || !exercise.caloriesBurned) {
-            throw new Error('Cardio exercises require minutes and calories burned');
+        if (!exercise.distance || !exercise.minutes || !exercise.caloriesBurned) {
+            throw new Error('Cardio exercises require distance, minutes, and calories burned');
         }
 
         // throw error if present:
@@ -25,8 +25,8 @@ function exerciseSchemaMiddleware (exercise) {
         }
         
         // throw error if present:
-        if (exercise.minutes || exercise.caloriesBurned) {
-            throw new Error('Weighted exercises cannot have minutes and calories burned');
+        if (exercise.distance || exercise.minutes || exercise.caloriesBurned) {
+            throw new Error('Weighted exercises cannot have distance, minutes, or calories burned');
         }
     }
 }

--- a/models/favorite.js
+++ b/models/favorite.js
@@ -40,6 +40,10 @@ const favoriteSchema = new mongoose.Schema({
                 type: Number,
                 min: 1,
             },
+            distance: {
+                type: Number,
+                min: 1
+            },
             minutes: {
                 type: Number,
                 min: 1

--- a/models/movement.js
+++ b/models/movement.js
@@ -18,8 +18,6 @@ const movementSchema = new mongoose.Schema({
     },
     musclesWorked: {
         type: Array,
-        required: true,
-        default: undefined,
     },
     type: {
         type: String,
@@ -34,6 +32,20 @@ const movementSchema = new mongoose.Schema({
     timestamps: true
 });
 
+
+// ensures that musclesWorked is only required for movements of type 'weighted'
+movementSchema.pre('save', function (next) {
+    // if type cardio, save with empty array
+    if (this.type === 'cardio')
+        this.musclesWorked = [];
+
+    // if type weighted, make sure array with at least 1 element 
+    else if (this.type === 'weighted') 
+        if (!Array.isArray(this.musclesWorked) || this.musclesWorked.length === 0) 
+            return next(new Error('Muscles worked is required for weighted movements.'));
+        
+    next();
+});
 
 // removes associated exercises from workout when a movement is deleted
 movementSchema.pre('remove', async function (next) {

--- a/models/movement.js
+++ b/models/movement.js
@@ -48,17 +48,17 @@ movementSchema.pre('save', function (next) {
 });
 
 // removes associated exercises from workout when a movement is deleted
-movementSchema.pre('remove', async function (next) {
+movementSchema.pre('deleteOne', async function (next) {
     try {
-        const workouts = await Workout.find({ 'exercise.movement': this._id });
+        const movementId = this.getQuery()._id;
 
-        const movementId = this._id;
+        const workouts = await Workout.find({ 'exercise.movement': movementId });
 
         for (const workout of workouts) {
             workout.exercise = workout.exercise.filter(function (exercise) {
                 return exercise.movement.toString() !== movementId._id.toString();
             });
-            if (workout.exercise.length === 0) await workout.remove();
+            if (workout.exercise.length === 0) await workout.deleteOne();
             else await workout.save();
         }
 

--- a/models/workout.js
+++ b/models/workout.js
@@ -28,6 +28,10 @@ const workoutSchema = new mongoose.Schema({
                 type: Number,
                 min: 1,
             },
+            distance: {
+                type: Number,
+                min: 1
+            },
             minutes: {
                 type: Number,
                 min: 1

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -57,8 +57,14 @@ $(document).ready(function () {
         }
         toggleForms(selectors);
     });
+    $('.movementTypeCheckbox').on('change', function () {
+        // uses separate toggling logic due to specific condition of only showing when 'weighted' is checked
+        if ($(this).is(':checked') && $(this).val() === 'weighted')
+            $('.musclesWorked').removeClass('d-none');
+        else $('.musclesWorked').addClass('d-none');
+    });
     $('#profilePhoto').on('change', enableSubmit);
-    $muscles.add($movementType).on('change', validateMovementForm);
+    $movementType.add($muscles).on('change', validateMovementForm);
     $('.movementSelect').each(handleWorkoutFormChange);
     $inputParent.on('change', '.movementSelect', handleWorkoutFormChange);
     $inputParent.on('change', enableWorkoutSubmit);
@@ -127,8 +133,10 @@ $(document).ready(function () {
 
     // validate that at least 1 muscle is selected, and the type of movement is determined before submitting
     function validateMovementForm () {
-        const validateMuscle = $muscles.is(':checked');
-        const validateType = $movementType.is(':checked');
+        const selectedMovementType = $('input[name="type"]:checked').val();
+        
+        const validateMuscle = selectedMovementType === 'weighted' ? $muscles.is(':checked') : true;
+        const validateType = selectedMovementType !== undefined;
         $movementSubmit.prop('disabled', !(validateMuscle && validateType));
     }
 

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -131,7 +131,7 @@ $(document).ready(function () {
         if ($(evt.target).val() !== '') $(evt.target).siblings().removeAttr('disabled');
     }
 
-    // validate that at least 1 muscle is selected, and the type of movement is determined before submitting
+    // validate the type of movement, and if weighted that at least 1 muscle is selected, is selected before submitting
     function validateMovementForm () {
         const selectedMovementType = $('input[name="type"]:checked').val();
         

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -57,11 +57,16 @@ $(document).ready(function () {
         }
         toggleForms(selectors);
     });
-    $('.movementTypeCheckbox').on('change', function () {
+    $('.movementTypeCheckbox, .typeFilter').on('change', function () {
         // uses separate toggling logic due to specific condition of only showing when 'weighted' is checked
-        if ($(this).is(':checked') && $(this).val() === 'weighted')
-            $('.musclesWorked').removeClass('d-none');
-        else $('.musclesWorked').addClass('d-none');
+        let eventTrigger = $(this);
+        let targetForm;
+
+        if ($(this).is('.movementTypeCheckbox'))
+            targetForm = $('.musclesWorked');
+        else targetForm = $('#muscleFilter');
+
+        toggleFormsBasedOnMovementType(eventTrigger, targetForm);
     });
     $('#profilePhoto').on('change', enableSubmit);
     $movementType.add($muscles).on('change', validateMovementForm);
@@ -124,6 +129,12 @@ $(document).ready(function () {
             const $element = $(selector);
             $element.toggleClass('d-none');
         }
+    }
+
+    function toggleFormsBasedOnMovementType (eventTrigger, targetForm) {
+        if (eventTrigger.is(':checked') && eventTrigger.val() === 'weighted')
+            targetForm.removeClass('d-none');
+        else targetForm.addClass('d-none');
     }
 
     // for profile photo submit button

--- a/seed/movementData.js
+++ b/seed/movementData.js
@@ -72,7 +72,6 @@ module.exports = [
     {
         name: 'Running',
         description: 'a classic run',
-        musclesWorked: ['Quadriceps', 'Hamstrings', 'Glutes', 'Calves', 'Abdominals'],
         type: 'cardio',
         createdBy: null,
     },

--- a/tests/controllers/favorites.test.js
+++ b/tests/controllers/favorites.test.js
@@ -95,6 +95,7 @@ beforeAll(async () => {
                 weight: ['100'],
                 sets: ['1'],
                 reps: ['1'],
+                distance: [''],
                 minutes: [''],
                 caloriesBurned: ['']
             },

--- a/tests/controllers/movements.test.js
+++ b/tests/controllers/movements.test.js
@@ -19,7 +19,7 @@ beforeAll(async () => {
     await mongoose.connect(process.env.MONGO_URL);
     await User.deleteMany({});
     await Movement.deleteMany({});
-    await Movement.create(movementData.slice(0, 5));
+    await Movement.create(movementData);
 
     movement = await Movement.findOne({}).lean();
 
@@ -54,10 +54,21 @@ describe('GET /movements', () => {
         expect(response.text).toContain(movementData[0].name);
     });
 
-    test('should filter the movements view', async () => {
+    test('should filter the movements view based on type', async () => {
         const response = await testSession
             .get('/movements')
-            .query({ muscle: 'Chest', page: 1 })
+            .query({ typeFilter: 'cardio', page: 1 })
+            .expect(200)
+            .expect('Content-Type', /html/);
+
+        expect(response.text).toContain('Movements');
+        expect(response.text).toContain('Running');
+    });
+
+    test('should filter the movements view based on muscles', async () => {
+        const response = await testSession
+            .get('/movements')
+            .query({ typeFilter: 'weighted', muscle: 'Chest', page: 1 })
             .expect(200)
             .expect('Content-Type', /html/);
 

--- a/tests/controllers/workouts.test.js
+++ b/tests/controllers/workouts.test.js
@@ -62,6 +62,7 @@ beforeAll(async () => {
                 weight: ['100'],
                 sets: ['1'],
                 reps: ['1'],
+                distance: [''],
                 minutes: [''],
                 caloriesBurned: ['']
             },
@@ -156,6 +157,7 @@ describe('POST /workouts', () => {
                 weight: ['100', '150'],
                 sets: ['1', '2'],
                 reps: ['1', '2'],
+                distance: ['', ''],
                 minutes: ['', ''],
                 caloriesBurned: ['', '']
             },
@@ -207,6 +209,7 @@ describe('PUT /workouts/:id', () => {
                     weight: ['5000'],
                     sets: ['1'],
                     reps: ['1'],
+                    distance: [''],
                     minutes: [''],
                     caloriesBurned: ['']
             },

--- a/tests/models/favorite.test.js
+++ b/tests/models/favorite.test.js
@@ -82,6 +82,7 @@ describe('Favorite model', () => {
                 weight: -1,
                 sets: 0,
                 reps: 0,
+                distance: 0,
                 minutes: 0,
                 caloriesBurned: 0,
             }],
@@ -208,7 +209,7 @@ describe('Favorite model\'s required exercise fields schema middleware', () => {
             exercise: [{ movement: cardioMovement }]
         }
 
-        await expectCreationError(cardioFavoriteMissingFields, 'Cardio exercises require minutes and calories burned');
+        await expectCreationError(cardioFavoriteMissingFields, 'Cardio exercises require distance, minutes, and calories burned');
     });
 
     test('should throw error when cardio type movement exercises have weighted fields', async () => {
@@ -219,6 +220,7 @@ describe('Favorite model\'s required exercise fields schema middleware', () => {
                 weight: 100,
                 sets: 1,
                 reps: 1,
+                distance: 1,
                 minutes: 1,
                 caloriesBurned: 1
             }]
@@ -244,11 +246,12 @@ describe('Favorite model\'s required exercise fields schema middleware', () => {
                 weight: 100,
                 sets: 1,
                 reps: 1,
+                distance: 1,
                 minutes: 1,
                 caloriesBurned: 1,
             }]
         }
 
-        await expectCreationError(weightedFavoriteWrongFields, 'Weighted exercises cannot have minutes and calories burned');
+        await expectCreationError(weightedFavoriteWrongFields, 'Weighted exercises cannot have distance, minutes, or calories burned');
     });
 });

--- a/tests/models/workout.test.js
+++ b/tests/models/workout.test.js
@@ -98,6 +98,7 @@ describe('Workout model', () => {
                 weight: -1,
                 sets: 0,
                 reps: 0,
+                distance: 0,
                 minutes: -1,
                 caloriesBurned: -1,
             }],
@@ -107,7 +108,7 @@ describe('Workout model', () => {
         const error = await expectValidationError(Workout, invalidExerciseData);
 
         // ensures errors for each min value violation are included
-        ['weight', 'sets', 'reps', 'minutes', 'caloriesBurned'].forEach(field => {
+        ['weight', 'sets', 'reps', 'distance', 'minutes', 'caloriesBurned'].forEach(field => {
             expect(error.errors[`exercise.0.${field}`]).toBeDefined();
         });
 
@@ -230,7 +231,7 @@ describe('Workout model\'s required exercise fields schema middleware', () => {
             exercise: [{ movement: cardioId }]
         }
 
-        await expectCreationError(cardioWorkoutMissingFields, 'Cardio exercises require minutes and calories burned');
+        await expectCreationError(cardioWorkoutMissingFields, 'Cardio exercises require distance, minutes, and calories burned');
     });
 
     test('should throw error when cardio type movement exercises have weighted fields', async () => {
@@ -241,6 +242,7 @@ describe('Workout model\'s required exercise fields schema middleware', () => {
                 weight: 100,
                 sets: 1,
                 reps: 1,
+                distance: 1,
                 minutes: 1,
                 caloriesBurned: 1,
             }]
@@ -266,11 +268,12 @@ describe('Workout model\'s required exercise fields schema middleware', () => {
                 weight: 100,
                 sets: 1,
                 reps: 1,
+                distance: 1,
                 minutes: 1,
                 caloriesBurned: 1,
             }]
         }
 
-        await expectCreationError(weightedWorkoutWrongFields, 'Weighted exercises cannot have minutes and calories burned');
+        await expectCreationError(weightedWorkoutWrongFields, 'Weighted exercises cannot have distance, minutes, or calories burned');
     });
 });

--- a/utilities/formatHelpers.js
+++ b/utilities/formatHelpers.js
@@ -3,7 +3,7 @@ const { muscleGroups } = require('./constants');
 // formatting the exercise array for create and update routes
 function formatWorkoutExercise(exercise) {
     const exerciseObjects = [];
-    const properties = ['movement', 'weight', 'sets', 'reps', 'minutes', 'caloriesBurned']; // all possible properties
+    const properties = ['movement', 'weight', 'sets', 'reps', 'distance', 'minutes', 'caloriesBurned']; // all possible properties
 
     // iterating through indices of 'movement' array to get access to indices of values in each key
     for (let i = 0; i < exercise.movement.length; i++) {
@@ -43,7 +43,7 @@ function formatFavoriteExercise(exercise, movement) {
 
     const keysByType = {
         weighted: ['weight', 'sets', 'reps'],
-        cardio: ['minutes', 'caloriesBurned']
+        cardio: ['distance', 'minutes', 'caloriesBurned']
     }
 
     // determines what keys the object will have based on type of movement

--- a/utilities/formatHelpers.js
+++ b/utilities/formatHelpers.js
@@ -20,9 +20,13 @@ function formatWorkoutExercise(exercise) {
 
 // format the movement data from req.body
 function formatMovementData(movementData, userId) {
-    const selectedMuscles = Object.keys(movementData.musclesWorked).filter(function (key) {
-        return muscleGroups.includes(key);
-    });
+    let selectedMuscles = [];
+
+    if (movementData.type === 'weighted') 
+        selectedMuscles = Object.keys(movementData.musclesWorked).filter(function (key) {
+            return muscleGroups.includes(key);
+        });
+
     const musclesWorked = [...selectedMuscles];
 
     const type = movementData.type

--- a/views/favorite/index.ejs
+++ b/views/favorite/index.ejs
@@ -48,7 +48,8 @@
                                         <%= exercise.sets %> x 
                                         <%= exercise.reps %>
                                     <% } else { %>
-                                        : <%= exercise.minutes %> mins,
+                                        : <%= exercise.distance %> miles, 
+                                        <%= exercise.minutes %> mins,
                                         <%= exercise.caloriesBurned %> cal
                                     <% } %>
                                 <% } %>

--- a/views/favorite/show.ejs
+++ b/views/favorite/show.ejs
@@ -26,6 +26,7 @@
                             <p>Repetitions per Set: <%= exercise.reps %></p>
                         <% } %>
                         <% if (exercise.movement.type === 'cardio') { %>
+                            <p>Distance: <%= exercise.distance %> miles</p>
                             <p>Duration: <%= exercise.minutes %> minutes</p>
                             <p>Calories Burned: <%= exercise.caloriesBurned %></p>
                         <% } %>

--- a/views/movement/edit.ejs
+++ b/views/movement/edit.ejs
@@ -19,16 +19,6 @@
                         <textarea rows="4" name="description" class="form-control" id="description" maxlength="150" style="height:100%"><%= movement.description %></textarea>
                         <label for="description">Description</label>
                     </div>
-                    <h4 class="mt-5 mb-3">Muscles Worked</h4>
-                    <div class="check-grid mb-5 mx-3">
-                        <% for (const muscle of muscleGroups) { %>
-                            <div class="form-check">
-                                <input type="checkbox" name="musclesWorked[<%= muscle %>]" class="form-check-input muscleCheckbox"
-                                    <%= movement.musclesWorked.includes(muscle) ? 'checked' : '' %>>
-                                <label for="<%= muscle %>"><%= muscle %></label>
-                            </div>
-                        <% } %>
-                    </div>
                     <h4 class="mt-5 mb-3">Cardio or Weighted?</h4>
                     <div class="mb-3">
                         <div class="form-check">
@@ -41,6 +31,16 @@
                                 <%= movement.type === 'weighted' ? 'checked' : '' %>>
                             <label for="weighted">Weighted</label>
                         </div>
+                    </div>
+                    <h4 class="mt-5 mb-3 <%= movement.type === 'cardio' ? 'd-none' : '' %> musclesWorked">Muscles Worked</h4>
+                    <div class="check-grid mb-5 mx-3 <%= movement.type === 'cardio' ? 'd-none' : '' %> musclesWorked">
+                        <% for (const muscle of muscleGroups) { %>
+                            <div class="form-check">
+                                <input type="checkbox" name="musclesWorked[<%= muscle %>]" class="form-check-input muscleCheckbox"
+                                    <%= movement.musclesWorked.includes(muscle) ? 'checked' : '' %>>
+                                <label for="<%= muscle %>"><%= muscle %></label>
+                            </div>
+                        <% } %>
                     </div>
                     <br>
                     <br>

--- a/views/movement/index.ejs
+++ b/views/movement/index.ejs
@@ -3,6 +3,7 @@
 
 <%- include('../partials/head'); %>
 
+
 <body>
     <div class="container">
         <%- include('../partials/nav'); %>
@@ -10,9 +11,19 @@
             <h2>Movements</h2>
             <div class="index center">
                 <form action="/movements" method="GET" class="form">
-                    <select multiple name="muscle" class="form-select" size="4">
+                    <div class="mb-3 index">
+                        <div class="form-check">
+                            <input type="radio" id="cardio" name="typeFilter" value="cardio" class="form-check-input typeFilter" <% if (typeFilter === 'cardio') { %> checked <% } %>>
+                            <label for="cardio" class="form-check-label">Cardio</label>
+                        </div>
+                        <div class="form-check">
+                            <input type="radio" id="weighted" name="typeFilter" value="weighted" class="form-check-input typeFilter" <% if (typeFilter === 'weighted') { %> checked <% } %>>
+                            <label for="weighted" class="form-check-label">Weighted</label>
+                        </div>
+                    </div>
+                    <select multiple name="muscle" class="form-select <% if (!typeFilter || typeFilter === 'cardio') { %> d-none <% } %>" id="muscleFilter" size="4">
                         <% for (const muscle of muscleGroups) { %>
-                            <option class="select-text" name="<%= muscle %>" value="<%= muscle %>">
+                            <option class="select-text" name="<%= muscle %>" value="<%= muscle %>" <% if (muscleFilter.includes(muscle)) { %> selected <% } %>>
                             <label for="<%= muscle %>"><%= muscle %></label>
                         <% } %>
                     </select>
@@ -48,12 +59,12 @@
                 </ul>
                 <div class="center mb-4">
                     <% if (currentPage > 1) { %>
-                        <a href="/movements?page=<%= Number(currentPage) - 1 %>" class="btn btn-outline-secondary btn-xs">Previous</a>
+                        <a href="/movements?page=<%= Number(currentPage) - 1 %>&typeFilter=<%= typeFilter %>&muscle=<%= muscleFilter %>" class="btn btn-outline-secondary btn-xs">Previous</a>
                     <% } %>
                     <% if (currentPage < totalPages) { %>
-                        <a href="/movements?page=<%= Number(currentPage) + 1 %>" class="btn btn-outline-secondary btn-xs">Next</a>
+                        <a href="/movements?page=<%= Number(currentPage) + 1 %>&typeFilter=<%= typeFilter %>&muscle=<%= Array.isArray(muscleFilter) ? muscleFilter.join(',') : muscleFilter %>" class="btn btn-outline-secondary btn-xs">Next</a>
                     <% } %>
-                </div>
+                </div>                
             <% } %>
             <div class="right mb-2">
                 <a href="/movements/new" class="btn btn-outline-secondary mb-3 btn-sm">Add a New Movement</a>

--- a/views/movement/new.ejs
+++ b/views/movement/new.ejs
@@ -21,15 +21,6 @@
                             style="height:100%"></textarea>
                         <label for="description">Description</label>
                     </div>
-                    <h4 class="mt-5 mb-3">Muscles Worked</h4>
-                    <div class="check-grid mb-5 mx-3">
-                        <% for (const muscle of muscleGroups) { %>
-                            <div class="form-check">
-                                <input type="checkbox" name="musclesWorked[<%= muscle %>]" class="form-check-input muscleCheckbox">
-                                <label for="<%= muscle %>"><%= muscle %></label>
-                            </div>
-                        <% } %>
-                    </div>
                     <h4 class="mt-5 mb-3">Cardio or Weighted?</h4>
                     <div class="mb-3">
                         <div class="form-check">
@@ -40,6 +31,15 @@
                             <input type="radio" name="type" value="weighted" class="form-check-input movementTypeCheckbox">
                             <label for="weighted">Weighted</label>
                         </div>
+                    </div>
+                    <h4 class="mt-5 mb-3 d-none musclesWorked">Muscles Worked</h4>
+                    <div class="check-grid mb-5 mx-3 d-none musclesWorked">
+                        <% for (const muscle of muscleGroups) { %>
+                            <div class="form-check">
+                                <input type="checkbox" name="musclesWorked[<%= muscle %>]" class="form-check-input muscleCheckbox">
+                                <label for="<%= muscle %>"><%= muscle %></label>
+                            </div>
+                        <% } %>
                     </div>
                     <br>
                     <br>

--- a/views/workout/edit.ejs
+++ b/views/workout/edit.ejs
@@ -58,6 +58,10 @@
                                     </div>
                                     <div class="form-floating cardioSection">
                                         <div class="form-floating">
+                                            <input type="number" name="exercise[distance][]" min="1" class="form-control form-control-sm mb-1 h-25" id="distance" value="<%= exercise.distance %>">
+                                            <label class="small-text" for="reps">Distance</label>
+                                        </div>
+                                        <div class="form-floating">
                                             <input type="number" name="exercise[minutes][]" min="1" class="form-control form-control-sm mb-1 h-25" id="minutes" value="<%= exercise.minutes %>">
                                             <label class="small-text" for="reps">Minutes</label>
                                         </div>

--- a/views/workout/new.ejs
+++ b/views/workout/new.ejs
@@ -48,6 +48,10 @@
                                 </div>
                                 <div class="form-floating cardioSection">
                                     <div class="form-floating">
+                                        <input type="number" name="exercise[distance][]" min="1" class="form-control form-control-sm mb-1 h-25" id="distance">
+                                        <label class="small-text" for="reps">Distance</label>
+                                    </div>
+                                    <div class="form-floating">
                                         <input type="number" name="exercise[minutes][]" min="1" class="form-control form-control-sm mb-1 h-25" id="minutes">
                                         <label class="small-text" for="reps">Minutes</label>
                                     </div>

--- a/views/workout/show.ejs
+++ b/views/workout/show.ejs
@@ -30,6 +30,7 @@
                             <p>Repetitions per Set: <%= exercise.reps %></p>
                         <% } %>
                         <% if (exercise.movement.type === 'cardio') { %>
+                            <p>Distance: <%= exercise.distance %> miles</p>
                             <p>Duration: <%= exercise.minutes %> minutes</p>
                             <p>Calories Burned: <%= exercise.caloriesBurned %></p>
                         <% } %>


### PR DESCRIPTION
For cardio movements, removes requirement of `musclesWorked` array and adds `distance` attribute.

Models -->
- movement
     - adds pre save validation middleware to enforce `musclesWorked = []` for cardio type and `Array.isArray(musclesWorked) && musclesWorked.length > 0` for weighted type
     - refactors to use `deleteOne()` due to deprecation of `remove()`
          - updates pre deleteOne middleware to delete any exercises from workouts that are associated with the movement being deleted
- workout and favorite
      - adds distance attribute to embedded exercise schema

Controllers -->
- movement
     - refactors delete route to use `deleteOne()` and trigger schema middleware
     - refactors update route to use `save()` and trigger schema middleware
     - adds filtering by type for index route

Views -->
- workout
     - updates edit, new, and show to render distance attribute as needed
- favorite
    - updates index and show to render distance attribute as needed
- movement
     - adds selection to filter by movement type on index

Public -->
- js
     - based on movement type selection, adds event handler to toggle show and hide of:
            - musclesWorked selection in movement new and edit 
            - muscleGroup selection in movement index for filter

Schema Middleware and Format Helpers --> 
- enforces and formats to make distance attribute required for cardio type
- formats to remove requirement for musclesWorked unless weighted type

Tests --> updates and adds models and controller tests to account for changes
Seed --> updates movement seed data to account for change to schema
